### PR TITLE
Copy contents of My Games rather than Move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Symlink support has been re-enabled as this appears to work (it didn't in Fallout 4/Skyrim).
 - Add a warning when installing Starfield Script Extender on Xbox Game Pass. 
 - Fixed installing EXEs to the game root incorrectly. 
+- Warn the user if they try to install SKSE to a non-Steam version of Starfield. 
 
 ## [0.3.0] - 2023-09-17
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { types, util } from "vortex-api";
+import { types } from "vortex-api";
 import { testSupported, install } from './installers/starfield-default-installer';
 import { isStarfield, openAppDataPath, openSettingsPath } from './util';
 import setup from './setup';
@@ -58,9 +58,7 @@ function main(context: types.IExtensionContext) {
     requiredFiles: [
       'Starfield.exe',
     ],
-    setup: util.toBlue(async (discovery) => {
-      await setup(discovery, context);
-    }),
+    setup: (discovery) => setup(discovery, context),
     supportedTools,
     requiresLauncher: requiresLauncher,
     details: {

--- a/src/installers/starfield-default-installer.ts
+++ b/src/installers/starfield-default-installer.ts
@@ -122,17 +122,23 @@ async function install(
 async function installSFSE(api: types.IExtensionApi, files: string[], SFSE: string): Promise<types.IInstallResult> {
     // Warn SFSE doesn't work with the Xbox release. 
     const discovery = api.getState().settings?.gameMode?.discovered?.[GAME_ID];
-    if (discovery?.store && discovery?.store !== 'steam') {
+    if ((discovery?.store && discovery?.store !== 'steam') || !discovery.path.toLowerCase().includes('steamapps')) {
+        const platform = discovery.store 
+            ? discovery.store.charAt(0).toUpperCase() + discovery.store.slice(1) 
+            : 'Unknown (The location was set manually in the Games tab to a non-Steamapps folder)';
+
         const userChoice = await api.showDialog(
             'info', 
             'Starfield Script Extender is not compatible', 
             {
-                text: 'Starfield Script Extender is only compatible with the Steam release of the game, but you are playing on a different platform.'+
+                text: 'Starfield Script Extender is only compatible with the Steam release of the game, but it looks like you are playing on a different platform.'+
+                `\n\nDetected Platform: ${platform}`+
                 '\n\nYou may continue to install this mod but it is not likely to work correctly.'
             },
             [
                 {
                     label: 'Cancel',
+                    default: true
                 },
                 {
                     label: 'Continue',

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -69,6 +69,15 @@ async function startLooseFilesCheck(context: types.IExtensionContext, iniPath: s
     let iniContent = (await fs.readFileAsync(iniPath,'utf-8')) ?? '';
     let ini = parse(iniContent);
 
+    // Check that Photo mode images are being re-routed.
+    if (ini?.General?.sPhotoModeFolder !== 'Photos') {
+      if (!ini.General) {
+            ini.General = {}
+      }
+
+      ini.General.sPhotoModeFolder = 'Photos';
+    }
+
     if (ini?.Archive?.bInvalidateOlderFiles !== '1' || ini?.Archive?.sResourceDataDirsFinal !== '') {
 
       // Required settings not configured. Loose files would not be loaded correctly.

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -33,6 +33,7 @@ export default async function setup(discovery: types.IDiscoveryResult, context: 
       // Check to see if it's already a symlink.
       if (!dataFolderStat.isSymbolicLink()) {
         await mergeFolderContents(myGamesData, gameDataFolder, true);
+        await fs.renameAsync(myGamesData, `${myGamesData} - Backup`);
         // await fs.moveAsync(myGamesData, gameDataFolder, { overwrite: false });
       }
       else {
@@ -44,10 +45,7 @@ export default async function setup(discovery: types.IDiscoveryResult, context: 
       log('debug', 'My Games folder for Starfield does not contain a "Data" folder yet.')
     }
     // Create a symlink to trick the game into using the game data folder. 
-    if (createSymlink) {
-      await fs.renameAsync(myGamesData, `${myGamesData} - Backup`);
-      await fs.symlinkAsync(gameDataFolder, myGamesData, 'junction')
-    }
+    if (createSymlink) await fs.symlinkAsync(gameDataFolder, myGamesData, 'junction')
   }
   catch(err) {
     log('error', 'Error checking for My Games Data path for Starfield', err);

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -44,7 +44,10 @@ export default async function setup(discovery: types.IDiscoveryResult, context: 
       log('debug', 'My Games folder for Starfield does not contain a "Data" folder yet.')
     }
     // Create a symlink to trick the game into using the game data folder. 
-    if (createSymlink) await fs.symlinkAsync(gameDataFolder, myGamesData, 'junction')
+    if (createSymlink) {
+      await fs.renameAsync(myGamesData, `${myGamesData} - Backup`);
+      await fs.symlinkAsync(gameDataFolder, myGamesData, 'junction')
+    }
   }
   catch(err) {
     log('error', 'Error checking for My Games Data path for Starfield', err);

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
 import { fs, log, selectors, types, util } from "vortex-api";
+import * as defaultFs from 'fs/promises';
 import { GAME_ID } from './common';
 import path from "path";
 
@@ -22,28 +23,28 @@ export async function mergeFolderContents(source: string, destination: string, o
       }
       // We can move the entire folder over. 
       else {
-        await fs.moveAsync(sourceFilePath, path.join(destination, sourceFile));
+        await defaultFs.cp(sourceFilePath, path.join(destination, sourceFile));
       }
-      await fs.rmdirAsync(sourceFilePath)
+      // await fs.rmdirAsync(sourceFilePath)
       continue;
     }
     // Otherwise we're dealing with a file. 
     else if (stats.isFile()) {
       // If the file doesn't exist, merge it over. 
       if (!destinationMatch || overwrite) {
-        await fs.moveAsync(sourceFilePath, path.join(destination, destinationMatch), { overwrite: true });
+        await fs.copyAsync(sourceFilePath, path.join(destination, destinationMatch), { overwrite: true });
         continue;
       }
       else {
         log('debug', 'Did not copy file as it already exists', { source: sourceFilePath, destination: path.join(destination, destinationMatch) })
-        await fs.unlinkAsync(sourceFilePath);
+        // await fs.unlinkAsync(sourceFilePath);
         continue;
       }
     }
     else return log('warn', 'Did not remove file as it is neither a file nor folder', sourceFilePath);
   }
 
-  await fs.rmdirAsync(source);
+  // await fs.rmdirAsync(source);
 }
 
 export const isStarfield = (context: types.IExtensionContext, gameId: string | string[] | undefined = undefined) => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,4 @@
 import { fs, log, selectors, types, util } from "vortex-api";
-import * as defaultFs from 'fs/promises';
 import { GAME_ID } from './common';
 import path from "path";
 
@@ -23,7 +22,7 @@ export async function mergeFolderContents(source: string, destination: string, o
       }
       // We can move the entire folder over. 
       else {
-        await defaultFs.cp(sourceFilePath, path.join(destination, sourceFile));
+        await fs.copyAsync(sourceFilePath, path.join(destination, sourceFile), { force: true });
       }
       // await fs.rmdirAsync(sourceFilePath)
       continue;


### PR DESCRIPTION
Removed the "toBlue" additional to the setup function (it was unnecesary!).

When migrating the user's My Games Data folder to the Game Data folder we now copy instead of move the files. The content of the My Games Data folder is now renamed to `...\My Games\Starfield\Data - Backup