### PR TITLE
Disable symlinks again 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ function main(context: types.IExtensionContext) {
     supportedTools,
     requiresLauncher: requiresLauncher,
     details: {
+      supportsSymlinks: false,
       steamAppId: parseInt(STEAMAPP_ID),
     },
   });


### PR DESCRIPTION
Symlinks don't work with certain animation mods and actually cause errors in-game.

# Example mods

- https://www.nexusmods.com/starfield/mods/2489 - Breaks the animation entirely causing softlocks
- https://www.nexusmods.com/starfield/mods/2645 - Breaks the animation entirely causing softlocks
- https://www.nexusmods.com/starfield/mods/2815 - Breaks the animation entirely causing softlocks
- https://www.nexusmods.com/starfield/mods/326 - Unverified
- https://www.nexusmods.com/starfield/mods/493 - Unverified