### PR TITLE
fixed inability to report some LOOT sorting errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.9.1] - 2024-08-14
+
+- Fixed inability to report _some_ loot sorting errors
+
 ## [1.9.0] - 2024-08-12
 
 - Versioning tidy up

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starfield",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Vortex Extension for Starfield",
   "author": "Nexus Mods",
   "private": true,

--- a/src/util.ts
+++ b/src/util.ts
@@ -526,7 +526,7 @@ export async function lootSort(api: types.IExtensionApi) {
     });
     const onSortCallback = async (err: Error, result: string[]) => {
       if (err) {
-        api.showErrorNotification('LOOT sort failed', err.message);
+        api.showErrorNotification('LOOT sort failed', err);
         api.dismissNotification('starfield-fblo-loot-sorting');
         return;
       }


### PR DESCRIPTION
This one can only happen when refusing to update to Vortex 1.12.1 or greater.

closes nexus-mods/vortex#16229