### PR TITLE
Fixed deploy event handlers executing while managing other games

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.10.3 - 2024-11-07
+## [1.10.4] - 2024-12-09
+
+- Fixed deployment event handlers executing while other games are managed
+
+## [1.10.3] - 2024-11-07
 - Fixed engine injectors (SFSE excluded) being erroneously flagged as the Game Pass ASI Loader
 
 ## [1.10.2] - 2024-09-30

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starfield",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "Vortex Extension for Starfield",
   "author": "Nexus Mods",
   "private": true,


### PR DESCRIPTION
Overall this is unnoticeable, but can slow down collections for other games where multiple phases are defined.