### PR TITLE
Update loot functionality constraint to support 2.0.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starfield",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "description": "Vortex Extension for Starfield",
   "author": "Nexus Mods",
   "private": true,

--- a/src/common.ts
+++ b/src/common.ts
@@ -26,7 +26,7 @@ export const INSTALLING_REQUIREMENTS_NOTIFICATION_ID = 'starfield-installing-req
 export const CONSTRAINT_PLUGIN_ENABLER = '<1.12.0';
 
 // This is used for Vortex's version. (pre-1.12.0 will not support FBLO loot sort)
-export const CONSTRAINT_LOOT_FUNCTIONALITY = '>1.12.0';
+export const CONSTRAINT_LOOT_FUNCTIONALITY = '>=1.12.0';
 //#endregion
 
 // This is the order we expect the native plugins to be arranged.


### PR DESCRIPTION
Original constraint `^1.2.0` cannot be satisfied by `2.0.0` - this will disable LOOT load order as an option. 