### PR TITLE
Add GitHub Action to publish to Nexus Mods

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -45,7 +45,7 @@ jobs:
             VERSION="$PKG_VERSION"
           fi
 
-          ZIP_NAME="Bethesda Import.zip"
+          ZIP_NAME="Starfield.zip"
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "zip_name=$ZIP_NAME" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,0 +1,100 @@
+name: Publish to Nexus Mods
+
+on:
+  workflow_dispatch:
+    inputs:
+          version:
+            description: 'Release version - package.json version will be used by default'
+            required: false
+
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Project
+    runs-on: ubuntu-latest
+
+    outputs: 
+      version: ${{ steps.meta.outputs.version }}
+      zip_name: ${{ steps.meta.outputs.zip_name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node (with yarn cache)
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      
+      - name: Compute build metadata
+        id: meta
+        shell: bash
+        run: |
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          INPUT_VERSION="${{ github.event.inputs.version }}"
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="$PKG_VERSION"
+          fi
+
+          ZIP_NAME="Bethesda Import.zip"
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "zip_name=$ZIP_NAME" >> "$GITHUB_OUTPUT"
+
+          echo "Using version: $VERSION"
+          echo "Zip name: $ZIP_NAME"
+
+      - name: Build
+        run: yarn build
+
+      - name: Verify dist exists
+        run: |
+          test -d dist
+          echo "dist folder found ✅"
+
+      - name: Zip dist
+        run: |
+          cd dist
+          zip -r "../${{ steps.meta.outputs.zip_name }}" .
+          cd ..
+          ls -lh "${{ steps.meta.outputs.zip_name }}"
+
+      - name: Upload dist zip artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: Starfield
+          path: ${{ steps.meta.outputs.zip_name }}
+          if-no-files-found: error
+  upload:
+    name: Upload to Nexus Mods
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      
+      - name: Get Extension Artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: Starfield
+
+      - name: Upload to Nexus Mods
+        uses: Nexus-Mods/upload-action@main
+        with:
+          api_key: ${{ secrets.NEXUSMODS_API_KEY }}
+          file_group_id: ${{ vars.NEXUSMODS_FILE_GROUP_ID }}
+          display_name: Starfield Support for Vortex         
+          filename: ${{ needs.build.outputs.zip_name }}
+          version: ${{ github.event.inputs.version || needs.build.outputs.version }}
+
+          

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -3,20 +3,23 @@ name: Publish to Nexus Mods
 on:
   workflow_dispatch:
     inputs:
-          version:
-            description: 'Release version - package.json version will be used by default'
-            required: false
-
+      version:
+        description: 'Release version - package.json version will be used by default'
+        required: false
 
 permissions:
   contents: read
+
+concurrency:
+  group: publish-nexus
+  cancel-in-progress: false
 
 jobs:
   build:
     name: Build Project
     runs-on: ubuntu-latest
 
-    outputs: 
+    outputs:
       version: ${{ steps.meta.outputs.version }}
       zip_name: ${{ steps.meta.outputs.zip_name }}
 
@@ -32,20 +35,27 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-      
+
       - name: Compute build metadata
         id: meta
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         shell: bash
         run: |
           PKG_VERSION="$(node -p "require('./package.json').version")"
-          INPUT_VERSION="${{ github.event.inputs.version }}"
+
           if [ -n "$INPUT_VERSION" ]; then
             VERSION="$INPUT_VERSION"
           else
             VERSION="$PKG_VERSION"
           fi
 
-          ZIP_NAME="Starfield.zip"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+            echo "::error::Invalid version format: $VERSION (expected semver)"
+            exit 1
+          fi
+
+          ZIP_NAME="Starfield-${VERSION}.zip"
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "zip_name=$ZIP_NAME" >> "$GITHUB_OUTPUT"
@@ -59,7 +69,7 @@ jobs:
       - name: Verify dist exists
         run: |
           test -d dist
-          echo "dist folder found ✅"
+          echo "dist folder found"
 
       - name: Zip dist
         run: |
@@ -74,15 +84,13 @@ jobs:
           name: Starfield
           path: ${{ steps.meta.outputs.zip_name }}
           if-no-files-found: error
+
   upload:
     name: Upload to Nexus Mods
     needs: build
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      
       - name: Get Extension Artifact
         uses: actions/download-artifact@v6
         with:
@@ -93,8 +101,6 @@ jobs:
         with:
           api_key: ${{ secrets.NEXUSMODS_API_KEY }}
           file_group_id: ${{ vars.NEXUSMODS_FILE_GROUP_ID }}
-          display_name: Starfield Support for Vortex         
+          display_name: Starfield Support for Vortex
           filename: ${{ needs.build.outputs.zip_name }}
-          version: ${{ github.event.inputs.version || needs.build.outputs.version }}
-
-          
+          version: ${{ needs.build.outputs.version }}


### PR DESCRIPTION
Add a workflow (publish-release.yaml) to automate building and publishing the project to Nexus Mods. The workflow is manually triggerable (workflow_dispatch) with an optional version input, sets up Node 24 with yarn cache, installs deps, builds the project, zips the dist folder, and uploads the artifact. The build job exports version and zip_name outputs (package.json version is used by default unless overridden). A follow-up job downloads the artifact and calls Nexus-Mods/upload-action with the configured API key and file group to publish the release.